### PR TITLE
Add support for macOS + simplify Package.swift file contents

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,31 +1,12 @@
 // swift-tools-version:5.5
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
 import PackageDescription
 
 let package = Package(
     name: "NSExpandableView",
-    platforms: [
-        .iOS(.v14)
-    ],
-    products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
-        .library(
-            name: "NSExpandableView",
-            targets: ["NSExpandableView"]),
-    ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    platforms: [.iOS(.v14), .macOS(.v11)],
+    products: [.library(name: "NSExpandableView", targets: ["NSExpandableView"])],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(
-            name: "NSExpandableView",
-            dependencies: []),
-        .testTarget(
-            name: "NSExpandableViewTests",
-            dependencies: ["NSExpandableView"]),
+        .target(name: "NSExpandableView"),
+        .testTarget( name: "NSExpandableViewTests"),
     ]
 )

--- a/Sources/NSExpandableView/NSExpandableView.swift
+++ b/Sources/NSExpandableView/NSExpandableView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
-@available(iOS 13.0, *)
 public struct NSExpandableView<TopContent: View, BottomContent: View>: View {
-    
     private let topContent: () -> TopContent
     private let bottomContent: () -> BottomContent
     private let cornerRadius: CGFloat
@@ -10,13 +8,21 @@ public struct NSExpandableView<TopContent: View, BottomContent: View>: View {
     private let shouldCollapseOnBottomTap: Bool
     private let backgroundColor: Color
     @State private var isExpanded = false
-    
-    public init(@ViewBuilder topContent: @escaping () -> TopContent,
-                @ViewBuilder bottomContent: @escaping () -> BottomContent,
-                cornerRadius: CGFloat = 10,
-                roundedCornerStyle: RoundedCornerStyle = .continuous,
-                shouldCollapseOnBottomTap: Bool = true,
-                backgroundColor: Color = Color(.secondarySystemBackground)) {
+
+    #if os(iOS)
+    public static var defaultBackgroundColor: Color { Color(.secondarySystemBackground) }
+    #else
+    public static var defaultBackgroundColor: Color { Color.gray.opacity(0.16) }
+    #endif
+
+    public init(
+        @ViewBuilder topContent: @escaping () -> TopContent,
+        @ViewBuilder bottomContent: @escaping () -> BottomContent,
+        cornerRadius: CGFloat = 10,
+        roundedCornerStyle: RoundedCornerStyle = .continuous,
+        shouldCollapseOnBottomTap: Bool = true,
+        backgroundColor: Color = Self.defaultBackgroundColor
+    ) {
         self.topContent = topContent
         self.bottomContent = bottomContent
         self.cornerRadius = cornerRadius
@@ -128,4 +134,3 @@ struct NSExpandableView_Previews: PreviewProvider {
         .padding()
     }
 }
-


### PR DESCRIPTION
Previously, this was not building for macOS platforms although nearly everything works exactly the same on that platform. I just had to provide an alternative for the missing `.systemSecondaryBackground` color.

Now, any frameworks/libs depending on this lib can also be made compatible with macOS.